### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The firewall module creates four different policies to be used by provisioning D
 ```hcl
 module "dcos-compute-firewall" {
   source  = "dcos-terraform/compute-firewall/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   network = "network_self_link"
   internal_subnets = "172.12.0.0/16"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-compute-firewall" {
  *   source  = "dcos-terraform/compute-firewall/gcp"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   network = "network_self_link"
  *   internal_subnets = "172.12.0.0/16"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2