### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "google_compute_firewall" "adminrouter" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "443"]
+    ports    = ["80", "443", "${var.adminrouter_grpc_proxy_port}"]
   }
 
   source_ranges = ["${var.admin_ips}"]

--- a/variables.tf
+++ b/variables.tf
@@ -34,3 +34,8 @@ variable "name_prefix" {
   description = "Name Prefix"
   default     = ""
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476